### PR TITLE
Use lists for both the existing and the new instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,17 @@
 Library and command line tool to enable service based zero-downtime deployment strategies for CoreOS fleet.
 
 
+## Design choices
+- Only instance based deployments are supported, non-instanced units will be removed
+- Only indexed instances are supported, all other instances will be removed
+- Expects the unit to do it's own health-checking/only exit with return `0`/running when the application is actually running
+- Will timeout if a unit doesn't reach it's desired state within the timeout limit. Overriding the default timeout is possible
+
 ## Limitations
 - Only does initial creates and updates using the `fs create command`, no other commands implemented yet
 - Only 1 update strategy supported: stop 1st instance, start 1st instance, stop 2nd instance, start 2nd instance, etc
-- Hard-coded to start updating instances from instance id 1
 - Only Python 2.7 is supported because of http://click.pocoo.org/5/python3 and https://github.com/coreos/bugs/issues/112
 - Defaults are declared in both `fs` as well the `fleet_helper` module because of https://github.com/pallets/click/issues/627
-- Expects the unit to do it's own health-checking/only return 0/running when the application is actually running
-- Will timeout if a unit doesn't reach it's desired state within the timeout limit
 - Tries to adhere to the rule that [instances and templates are homogenous](https://coreos.com/fleet/docs/latest/unit-files-and-scheduling.html#template-unit-files), but it's not 100% compliant to it yet
 
 

--- a/fleet_service.py
+++ b/fleet_service.py
@@ -1,3 +1,4 @@
+import re
 import fleet.v1 as fleet
 import fleet_helper
 from pkg_resources import get_distribution, DistributionNotFound
@@ -12,6 +13,13 @@ except DistributionNotFound:
 
 class FleetService(fleet_helper.FleetHelper):
     """Service based zero-downtime deployment for CoreOS fleet"""
+    def __init__(self, fleet_uri, timeout):
+        super(FleetService, self).__init__(fleet_uri, timeout)
+        self.new_instances = []
+        self.existing_service_instances = []
+        self.our_existing_service_instances = []
+        self.wrong_instance_units = []
+
 
     def create_service(self, service_name, unit_file, count=3):
         """Create a service"""
@@ -22,43 +30,68 @@ class FleetService(fleet_helper.FleetHelper):
         self.logger.info('Creating service ' + service_name)
         self.logger.info('Desired instance count: ' + str(count))
 
-        # Get all units so we can find old template and instances of this service
-        fleet_units = self.get_units()
+        # Create list of new instances of this service
+        for i in range(0, count):
+            instance = i + 1
+            instance_unit_name = service_name + '@' + str(instance) + '.service'
+            self.new_instances.append(instance_unit_name)
+        self.logger.info('Desired instances: ' + str(self.new_instances))
 
-        # Get list of old instances of this service
-        existing_unit_instances = self.get_unit_instances(fleet_units, service_name)
-        self.logger.info('Existing instance count: ' + str(len(existing_unit_instances)))
+        # Get all units so we can find old template and instances of this service
+        self.get_units()
+
+        # Get existing instances of this service
+        self.existing_service_instances = sorted(self.get_unit_instances(service_name))
+        self.logger.info('Existing instance count: ' + str(len(self.existing_service_instances)))
+        self.logger.info('Existing instances: ' + str(self.existing_service_instances))
+
+        # Get existing instances we manage
+        our_unit_instance_pattern = re.compile(r"^" + re.escape(service_name) + r"@(\d+)\.service")
+        self.our_existing_service_instances = sorted([unit for unit in self.existing_service_instances if our_unit_instance_pattern.match(unit)])
+        self.logger.info('Existing instances managed by us: ' + str(self.our_existing_service_instances))
 
         # Destroy non-instanced unit if it exists
         non_instanced_unit_name = service_name + '.service'
-        if any(unit['name'] == non_instanced_unit_name for unit in fleet_units):
+        if any(unit['name'] == non_instanced_unit_name for unit in self.fleet_units):
             self.logger.warning('Destroying non-instance unit ' + non_instanced_unit_name)
             self.destroy_unit(non_instanced_unit_name)
 
+        # Destroy instances we don't manage
+        self.wrong_instance_units = sorted(set(self.existing_service_instances) - set(self.our_existing_service_instances))
+        if len(self.wrong_instance_units) > 0:
+            self.logger.warning('Destroying non-matching instance units ' + str(self.wrong_instance_units))
+        for unit in self.wrong_instance_units:
+            self.destroy_unit(unit)
+
         # Destroy old template if it exists
-        if any(unit['name'] == template_unit_name for unit in fleet_units):
-            self.logger.info('Destroying template ' + template_unit_name)
+        if any(unit['name'] == template_unit_name for unit in self.fleet_units):
+            self.logger.info('Destroying old template ' + template_unit_name)
             self.destroy_unit(template_unit_name)
 
         # Submit new template to fleet
         self.logger.info('Submitting new template ' + template_unit_name)
         self.create_unit(template_unit_name, template_unit)
 
-        # Update old instances/start new instances
-        maximum_instances = max(len(existing_unit_instances), count)
-        self.logger.debug('Maximum instances: ' + str(maximum_instances))
-        for i in range(0, maximum_instances):
-            instance = i + 1
-            self.logger.debug('Current instance: ' + str(instance))
-            instance_unit_name = service_name + '@' + str(instance) + '.service'
+        # Create new instances that don't exist yet
+        instances_to_create = sorted(set(self.new_instances) - set(self.our_existing_service_instances))
+        if len(instances_to_create) > 0:
+            self.logger.info('Creating new instances: ' + str(instances_to_create))
+        for instance in instances_to_create:
+            self.create_unit(instance, instance_unit)
 
-            # Destroy the old instance if it exists
-            if any(unit['name'] == instance_unit_name for unit in fleet_units):
-                self.destroy_instance(instance_unit_name)
+        # Update instances that already exist
+        instances_to_update = sorted(set(self.our_existing_service_instances) & set(self.new_instances))
+        if len(instances_to_update) > 0:
+            self.logger.info('Updating existing instances: ' + str(instances_to_update))
+        for instance in instances_to_update:
+            self.destroy_and_create_unit(instance, instance_unit)
 
-            # Create and start the new instance if we're still at or below the desired count
-            if instance <= (count):
-                self.create_instance(instance_unit_name, instance_unit)
+        # Destroy existing instances that should no longer exist
+        instances_to_destroy = sorted(set(self.our_existing_service_instances) - set(self.new_instances))
+        if len(instances_to_destroy) > 0:
+            self.logger.info('Destroying existing instances: ' + str(instances_to_destroy))
+        for instance in instances_to_destroy:
+            self.destroy_unit(instance)
 
 
     def ps(self):


### PR DESCRIPTION
This allows us to compare the 2 lists and first start the instances that don't exist yet, then cycle the instances that already exist and then stop the instances that no longer should exist.
Also added is the removal + a warning message of a non-instanced unit and non-matching instances for this service.

I'm not 100% happy with the regex I had to add to `FleetService`, whereas the other ones all live in `FleetHelper`. Maybe it makes sense to move the matching of units that aren't supported there as well?

@amochtar can you review/feedback?

Sample output with debugging:

```
# Units before
core@core-01 /tmp $ fleetctl list-units
UNIT            MACHINE             ACTIVE  SUB
crap.service        78cd7666.../172.17.8.103    active  running
crap@10.service     1e5729bc.../172.17.8.101    active  running
crap@2.service      1e5729bc.../172.17.8.101    active  running
crap@3.service      78cd7666.../172.17.8.103    active  running
crap@abc.service    dd5358c0.../172.17.8.102    active  running

(.venv) ~/s/s/fleet-service:use-lists-for-new-and-existing-instances ❯ ./fs -v DEBUG create --count 2 crap crap.service
Creating service crap
Desired instance count: 2
Desired instances: [u'crap@1.service', u'crap@2.service']
Existing instance count: 3
Existing instances: [u'crap@10.service', u'crap@2.service', u'crap@3.service']
warning: Destroying non-instance unit crap.service
debug: Destroying unit: crap.service
debug: Waiting for unit crap.service to reach state None
debug: crap.service state: None
warning: Destroying non-matching instance units [u'crap@abc.service']
debug: Destroying unit: crap@abc.service
debug: Waiting for unit crap@abc.service to reach state None
debug: crap@abc.service state: None
Destroying old template crap@.service
debug: Destroying unit: crap@.service
debug: Waiting for unit crap@.service to reach state None
debug: crap@.service state: None
Submitting new template crap@.service
debug: Creating new unit: crap@.service with desired state inactive
debug: Waiting for unit crap@.service to reach state inactive
debug: crap@.service state: inactive
Creating new instances: set([u'crap@1.service'])
Creating instance crap@1.service
debug: Creating new unit: crap@1.service with desired state launched
debug: Waiting for unit crap@1.service to reach state launched
debug: crap@1.service state: inactive
debug: crap@1.service state: inactive
debug: crap@1.service state: inactive
debug: crap@1.service state: inactive
debug: crap@1.service state: inactive
debug: crap@1.service state: inactive
debug: crap@1.service state: inactive
debug: crap@1.service state: inactive
debug: crap@1.service state: inactive
debug: crap@1.service state: inactive
debug: crap@1.service state: launched
debug: Waiting for unit crap@1.service to reach SystemD state active
debug: crap@1.service SystemD state: activating
debug: crap@1.service SystemD state: activating
debug: crap@1.service SystemD state: activating
debug: crap@1.service SystemD state: activating
debug: crap@1.service SystemD state: activating
debug: crap@1.service SystemD state: activating
debug: crap@1.service SystemD state: active
Updating existing instances: set([u'crap@2.service'])
Destroying instance crap@2.service
debug: Destroying unit: crap@2.service
debug: Waiting for unit crap@2.service to reach state None
debug: crap@2.service state: None
debug: Waiting for unit crap@2.service to reach SystemD state None
debug: crap@2.service SystemD state: active
debug: crap@2.service SystemD state: active
debug: crap@2.service SystemD state: active
debug: crap@2.service SystemD state: active
debug: crap@2.service SystemD state: None
Creating instance crap@2.service
debug: Creating new unit: crap@2.service with desired state launched
debug: Waiting for unit crap@2.service to reach state launched
debug: crap@2.service state: inactive
debug: crap@2.service state: inactive
debug: crap@2.service state: inactive
debug: crap@2.service state: inactive
debug: crap@2.service state: inactive
debug: crap@2.service state: inactive
debug: crap@2.service state: inactive
debug: crap@2.service state: inactive
debug: crap@2.service state: inactive
debug: crap@2.service state: inactive
debug: crap@2.service state: inactive
debug: crap@2.service state: inactive
debug: crap@2.service state: launched
debug: Waiting for unit crap@2.service to reach SystemD state active
debug: crap@2.service SystemD state: activating
debug: crap@2.service SystemD state: activating
debug: crap@2.service SystemD state: activating
debug: crap@2.service SystemD state: activating
debug: crap@2.service SystemD state: activating
debug: crap@2.service SystemD state: activating
debug: crap@2.service SystemD state: activating
debug: crap@2.service SystemD state: active
Destroying existing instances: set([u'crap@3.service', u'crap@10.service'])
Destroying instance crap@3.service
debug: Destroying unit: crap@3.service
debug: Waiting for unit crap@3.service to reach state None
debug: crap@3.service state: None
debug: Waiting for unit crap@3.service to reach SystemD state None
debug: crap@3.service SystemD state: active
debug: crap@3.service SystemD state: active
debug: crap@3.service SystemD state: active
debug: crap@3.service SystemD state: None
Destroying instance crap@10.service
debug: Destroying unit: crap@10.service
debug: Waiting for unit crap@10.service to reach state None
debug: crap@10.service state: None
debug: Waiting for unit crap@10.service to reach SystemD state None
debug: crap@10.service SystemD state: active
debug: crap@10.service SystemD state: active
debug: crap@10.service SystemD state: active
debug: crap@10.service SystemD state: active
debug: crap@10.service SystemD state: active
debug: crap@10.service SystemD state: active
debug: crap@10.service SystemD state: active
debug: crap@10.service SystemD state: active
debug: crap@10.service SystemD state: active
debug: crap@10.service SystemD state: None

# Units after
core@core-01 /tmp $ fleetctl list-units
UNIT        MACHINE             ACTIVE  SUB
crap@1.service  dd5358c0.../172.17.8.102    active  running
crap@2.service  1e5729bc.../172.17.8.101    active  running
```
