### PR TITLE
Add restart parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 **/__pycache__
 dist
 *.service
+.python-version

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ fs --help
 ## How to develop
 ```
 # Create a virtualenv with python 2.7
- virtualenv -p python2.7 .venv
+virtualenv -p python2.7 .venv
 # Activate the virtualenv
 source .venv/bin/activate
 # Install the dependencies

--- a/fleet_service.py
+++ b/fleet_service.py
@@ -21,11 +21,14 @@ class FleetService(fleet_helper.FleetHelper):
         self.wrong_instance_units = []
 
 
-    def create_service(self, service_name, unit_file, count=3):
+    def create_service(self, service_name, unit_file, count=3, restart=None):
         """Create a service"""
         template_unit_name = service_name + '@.service'
         template_unit = fleet.Unit(from_file=unit_file, desired_state='inactive')
         instance_unit = fleet.Unit(from_file=unit_file, desired_state='launched')
+        if restart:
+            self.set_restart_strategy(template_unit, restart)
+            self.set_restart_strategy(instance_unit, restart)
 
         self.logger.info('Creating service ' + service_name)
         self.logger.info('Desired instance count: ' + str(count))
@@ -106,3 +109,11 @@ class FleetService(fleet_helper.FleetHelper):
 
         self.logger.debug(instances)
         return sorted(instances.items())
+
+
+    def set_restart_strategy(self, unit, restart):
+        """Set restart strategy for unit
+        Will override any setting in the give unit
+        """
+        unit.remove_option('Service', 'Restart')
+        unit.add_option('Service', 'Restart', restart)

--- a/fs
+++ b/fs
@@ -24,10 +24,11 @@ def cli(ctx, fleetctl_endpoint, timeout):
 @click.argument('service-name', type=str)
 @click.argument('unit-file', type=click.Path(exists=True))
 @click.option('--count', type=int, default=3)
+@click.option('--restart', type=click.Choice(['always', 'no']), default=None, help='Overrides the Restart parameter of the unit')
 @click.pass_obj
-def create(ctx, service_name, unit_file, count):
+def create(ctx, service_name, unit_file, count, restart):
     """Start a service"""
-    ctx.create_service(service_name, unit_file, count)
+    ctx.create_service(service_name, unit_file, count, restart)
 
 
 @cli.command()


### PR DESCRIPTION
I've made the restart parameter optional, and by default it will not alter the unit. Only when specifying either `always` or `no` (I followed the systemd naming) explicitly, it will update the unit.

@simonvanderveldt / @pwillemse please review
