### PR TITLE
Remove restart override from create_service

### DIFF
--- a/fleet_service.py
+++ b/fleet_service.py
@@ -21,14 +21,11 @@ class FleetService(fleet_helper.FleetHelper):
         self.wrong_instance_units = []
 
 
-    def create_service(self, service_name, unit_file, count=3, restart=None):
+    def create_service(self, service_name, unit_file, count=3):
         """Create a service"""
         template_unit_name = service_name + '@.service'
         template_unit = fleet.Unit(from_file=unit_file, desired_state='inactive')
         instance_unit = fleet.Unit(from_file=unit_file, desired_state='launched')
-        if restart:
-            self.set_restart_strategy(template_unit, restart)
-            self.set_restart_strategy(instance_unit, restart)
 
         self.logger.info('Creating service ' + service_name)
         self.logger.info('Desired instance count: ' + str(count))
@@ -108,11 +105,3 @@ class FleetService(fleet_helper.FleetHelper):
 
         self.logger.debug(instances)
         return sorted(instances.items())
-
-
-    def set_restart_strategy(self, unit, restart):
-        """Set restart strategy for unit
-        Will override any setting in the give unit
-        """
-        unit.remove_option('Service', 'Restart')
-        unit.add_option('Service', 'Restart', restart)

--- a/fs
+++ b/fs
@@ -24,11 +24,10 @@ def cli(ctx, fleetctl_endpoint, timeout):
 @click.argument('service-name', type=str)
 @click.argument('unit-file', type=click.Path(exists=True))
 @click.option('--count', type=int, default=3)
-@click.option('--restart', type=click.Choice(['always', 'no']), default=None, help='Overrides the Restart parameter of the unit')
 @click.pass_obj
-def create(ctx, service_name, unit_file, count, restart):
+def create(ctx, service_name, unit_file, count):
     """Start a service"""
-    ctx.create_service(service_name, unit_file, count, restart)
+    ctx.create_service(service_name, unit_file, count)
 
 
 @cli.command()


### PR DESCRIPTION
It doesn't belong in fleet_service, the restart option should be set at the unit level before it's submitted to fleet_service.

@amochtar as discussed removing what we added in #7 :)
