### PR TITLE
Fix KeyError on missing currentState

### DIFF
--- a/fleet_helper.py
+++ b/fleet_helper.py
@@ -77,7 +77,7 @@ class FleetHelper(object):
         return unit_state
 
 
-    def wait_for_unit_state(self, unit_name, desired_state):
+    def wait_for_unit_fleet_state(self, unit_name, desired_state):
         """Wait for a unit to reach a desired state, will timeout after #self.__attempts"""
         self.logger.debug('Waiting for unit ' + str(unit_name) + ' to reach state ' + str(desired_state))
         i = 0
@@ -129,7 +129,7 @@ class FleetHelper(object):
             self.fleet_client.create_unit(unit_name, unit)
         except fleet.APIError as error:
             raise SystemExit('Unable to create unit: ' + format(error))
-        self.wait_for_unit_state(unit_name, unit.desiredState)
+        self.wait_for_unit_fleet_state(unit_name, unit.desiredState)
         if unit.desiredState == 'launched':
             self.wait_for_unit_systemd_state(unit_name, 'active')
 
@@ -141,7 +141,7 @@ class FleetHelper(object):
             self.fleet_client.destroy_unit(unit_name)
         except fleet.APIError as error:
             raise SystemExit('Unable to destroy unit ' + format(error))
-        self.wait_for_unit_state(unit_name, None)
+        self.wait_for_unit_fleet_state(unit_name, None)
         self.wait_for_unit_systemd_state(unit_name, None)
 
 

--- a/fleet_helper.py
+++ b/fleet_helper.py
@@ -66,8 +66,8 @@ class FleetHelper(object):
         self.get_units()
         fleet_unit = next((unit for unit in self.fleet_units if unit['name'] == unit_name), None)
 
-        if fleet_unit != None:
-            unit_state = fleet_unit.currentState
+        if fleet_unit is not None and 'currentState' in fleet_unit:
+            unit_state = fleet_unit['currentState']
 
         self.logger.debug(str(unit_name) + ' state: ' + str(unit_state))
         return unit_state

--- a/fleet_helper.py
+++ b/fleet_helper.py
@@ -94,7 +94,7 @@ class FleetHelper(object):
         self.get_systemd_states()
         fleet_unit_systemd_state = next((unit for unit in self.fleet_systemd_states if unit['name'] == unit_name), None)
 
-        if fleet_unit_systemd_state != None:
+        if fleet_unit_systemd_state is not None and 'systemdActiveState' in fleet_unit_systemd_state:
             systemd_state = fleet_unit_systemd_state['systemdActiveState']
 
         self.logger.debug(unit_name + ' SystemD state: ' + str(systemd_state))

--- a/fleet_helper.py
+++ b/fleet_helper.py
@@ -34,7 +34,6 @@ class FleetHelper(object):
         except ValueError as error:
             raise SystemExit('Unable to discover fleet: ' + format(error))
 
-
     def get_units(self):
         """Get a list of all units
         https://coreos.com/fleet/docs/latest/api-v1.html#list-units"""
@@ -43,7 +42,6 @@ class FleetHelper(object):
         except fleet.APIError as error:
             raise SystemExit('Unable to get unit list: ' + format(error))
 
-
     def get_systemd_states(self):
         """"Get a list of SystemD states
         https://coreos.com/fleet/docs/latest/api-v1.html#current-unit-state"""
@@ -51,7 +49,6 @@ class FleetHelper(object):
             self.fleet_systemd_states = self.fleet_client.list_unit_states()
         except fleet.APIError as error:
             raise SystemExit('Unable to get unit states: ' + format(error))
-
 
     def get_unit_instances(self, unit_name):
         """Get a list of instances for a unit"""
@@ -62,7 +59,6 @@ class FleetHelper(object):
                 unit_instances.append(unit.name)
 
         return unit_instances
-
 
     def get_unit_fleet_state(self, unit_name):
         """Get a unit's current state"""
@@ -75,7 +71,6 @@ class FleetHelper(object):
 
         self.logger.debug(str(unit_name) + ' state: ' + str(unit_state))
         return unit_state
-
 
     def wait_for_unit_fleet_state(self, unit_name, desired_state):
         """Wait for a unit to reach a desired state, will timeout after #self.__attempts"""
@@ -91,7 +86,6 @@ class FleetHelper(object):
         else:
             raise SystemExit('Timed out waiting for unit ' + unit_name + ' to reach state ' + str(desired_state))
 
-
     def get_unit_systemd_state(self, unit_name):
         """Get unit's SystemD state
         See https://github.com/coreos/fleet/blob/master/Documentation/states.md#systemd-states
@@ -105,7 +99,6 @@ class FleetHelper(object):
 
         self.logger.debug(unit_name + ' SystemD state: ' + str(systemd_state))
         return systemd_state
-
 
     def wait_for_unit_systemd_state(self, unit_name, desired_state):
         """Wait for a unit to reach a desired state in SystemD, will timeout after #self.__attempts"""
@@ -121,7 +114,6 @@ class FleetHelper(object):
         else:
             raise SystemExit('Timed out waiting for unit ' + unit_name + ' to reach state ' + str(desired_state))
 
-
     def create_unit(self, unit_name, unit):
         """Submit a new unit"""
         self.logger.debug('Creating new unit: ' + unit_name + ' with desired state ' + unit.desiredState)
@@ -133,7 +125,6 @@ class FleetHelper(object):
         if unit.desiredState == 'launched':
             self.wait_for_unit_systemd_state(unit_name, 'active')
 
-
     def destroy_unit(self, unit_name):
         """Destroy a unit"""
         self.logger.debug('Destroying unit: ' + unit_name)
@@ -143,7 +134,6 @@ class FleetHelper(object):
             raise SystemExit('Unable to destroy unit ' + format(error))
         self.wait_for_unit_fleet_state(unit_name, None)
         self.wait_for_unit_systemd_state(unit_name, None)
-
 
     def destroy_and_create_unit(self, unit_name, unit):
         """Do a verified destroy and then a verified create of a unit"""

--- a/fleet_service.py
+++ b/fleet_service.py
@@ -20,7 +20,6 @@ class FleetService(fleet_helper.FleetHelper):
         self.our_existing_service_instances = []
         self.wrong_instance_units = []
 
-
     def create_service(self, service_name, unit_file, count=3):
         """Create a service"""
         template_unit_name = service_name + '@.service'
@@ -93,7 +92,6 @@ class FleetService(fleet_helper.FleetHelper):
         for instance in instances_to_destroy:
             self.destroy_unit(instance)
 
-
     def destroy_service(self, service_name):
         """Destroy a service"""
         template_unit_name = service_name + '@.service'
@@ -137,7 +135,6 @@ class FleetService(fleet_helper.FleetHelper):
             self.logger.info('Destroying instances: ' + str(self.our_existing_service_instances))
         for instance in sorted(self.our_existing_service_instances, reverse=True):
             self.destroy_unit(instance)
-
 
     def ps(self):
         """Return service state"""


### PR DESCRIPTION
@amochtar @pwillemse please review and merge if OK.
Small change to fix #14 
Apparently even though the python-fleet library already [checks if the unit info comes from fleet](https://github.com/cnelson/python-fleet/blob/master/fleet/v1/objects/unit.py#L226) there's still no guarantee the other fields apart from `name` are present.
See also https://python-fleet.readthedocs.io/en/latest/unit/#available-once-units-are-submitted-to-fleet (which doesn't hint at this behaviour)

I've applied the same behaviour to the reading of the SystemD state.

I haven't been able to recreate the problem scenario locally, so can't fully validate this. My guess is that it's caused by fleet being less loaded than it was on production which apparently can cause units that are available in fleet (they have a name field) to not have all of their other fields including the `currentState` field that we're checking.

I have validated that deploying still works though for both changes introduced here.
Maybe we could/should add a test for this?
