### PR TITLE
Make list_services/ls actually list services instead of units.

### DIFF
--- a/fleet_service.py
+++ b/fleet_service.py
@@ -143,6 +143,7 @@ class FleetService(fleet_helper.FleetHelper):
         service_name_search = re.search(service_name_pattern, unit_name)
         if service_name_search:
             service_name = service_name_search.group(1)
+
         return service_name
 
     def list_services(self):
@@ -170,13 +171,13 @@ class FleetService(fleet_helper.FleetHelper):
             fleet_units = list(self.fleet_client.list_unit_states())
         except fleet.APIError as exc:
             raise SystemExit('Unable to list units: ' + str(exc))
-        self.logger.debug(fleet_units)
+        self.logger.debug('Fleet units: ' + str(fleet_units))
 
         try:
             fleet_machines = list(self.fleet_client.list_machines())
         except fleet.APIError as exc:
             raise SystemExit('Unable to list machines: ' + str(exc))
-        self.logger.debug(fleet_machines)
+        self.logger.debug('Fleet machines: ' + str(fleet_machines))
 
         machines = []
         for machine in fleet_machines:
@@ -185,6 +186,6 @@ class FleetService(fleet_helper.FleetHelper):
                 if unit['machineID'] == machine.id:
                     machine_units.append(unit.as_dict())
             machines.append({'id': machine.id, 'ip': machine.primaryIP, 'units': machine_units, 'metadata': machine.metadata})
+        self.logger.debug('Fleet machines and their units: ' + str(machines))
 
-        self.logger.debug(machines)
         return machines

--- a/fs
+++ b/fs
@@ -45,8 +45,11 @@ def destroy(ctx, service_name):
 def ls(ctx):
     """List all services"""
     services = ctx.list_services()
-    for key, value in services:
-        print(key + ": " + str(len(value)))
+    services_table = []
+    for service_name, service_instances in sorted(services.iteritems()):
+        service_instance_count = len(service_instances)
+        services_table.append(OrderedDict([['NAME', service_name], ['INSTANCES', service_instance_count]]))
+    click.echo(tabulate(services_table, headers="keys", tablefmt="plain"))
 
 
 @cli.command()
@@ -60,7 +63,7 @@ def lm(ctx):
         machine_units = len(machine['units'])
         machine_metadata = ','.join("%s=%s" % (key, str(val)) for (key, val) in machine['metadata'].iteritems())
         machines_table.append(OrderedDict([['ID', machine_id_short], ['IP', machine['ip']], ['UNITS', machine_units], ['METADATA', machine_metadata]]))
-    print tabulate(machines_table, headers="keys", tablefmt="plain")
+    click.echo(tabulate(machines_table, headers="keys", tablefmt="plain"))
 
 if __name__ == "__main__":
     cli()

--- a/fs
+++ b/fs
@@ -47,8 +47,26 @@ def ls(ctx):
     services = ctx.list_services()
     services_table = []
     for service_name, service_instances in sorted(services.iteritems()):
-        service_instance_count = len(service_instances)
-        services_table.append(OrderedDict([['NAME', service_name], ['INSTANCES', service_instance_count]]))
+        # States from https://github.com/systemd/systemd/blob/493fd52f1ada36bfe63301d4bb50f7fd2b38c670/src/basic/unit-name.c#L867
+        service_systemd_active_states = {
+            'active': 0,
+            'failed': 0,
+            'inactive': 0,
+            'activating': 0,
+            'deactivating': 0,
+            'reloading': 0
+        }
+        for service_instance in service_instances:
+            service_systemd_active_states[service_instance['systemdActiveState']] += 1
+        services_table.append(OrderedDict([
+            ['NAME', service_name],
+            ['ACTIVE', service_systemd_active_states['active']],
+            ['FAILED', service_systemd_active_states['failed']],
+            ['INACTIVE', service_systemd_active_states['inactive']],
+            ['ACTIVATING', service_systemd_active_states['activating']],
+            ['DEACTIVATING', service_systemd_active_states['deactivating']],
+            ['RELOADING', service_systemd_active_states['reloading']]
+        ]))
     click.echo(tabulate(services_table, headers="keys", tablefmt="plain"))
 
 

--- a/fs
+++ b/fs
@@ -78,9 +78,14 @@ def lm(ctx):
     machines_table = []
     for machine in machines:
         machine_id_short = machine['id'][:8] + '...'
-        machine_units = len(machine['units'])
+        machine_unit_count = len(machine['units'])
         machine_metadata = ','.join("%s=%s" % (key, str(val)) for (key, val) in machine['metadata'].iteritems())
-        machines_table.append(OrderedDict([['ID', machine_id_short], ['IP', machine['ip']], ['UNITS', machine_units], ['METADATA', machine_metadata]]))
+        machines_table.append(OrderedDict([
+            ['ID', machine_id_short],
+            ['IP', machine['ip']],
+            ['UNITS', machine_unit_count],
+            ['METADATA', machine_metadata]
+        ]))
     click.echo(tabulate(machines_table, headers="keys", tablefmt="plain"))
 
 if __name__ == "__main__":


### PR DESCRIPTION
`fs` will show unit counts per service. 

[edit] Updated, it now shows a count for all systemdActiveStates :)
```
./fs ls
NAME             ACTIVE    FAILED    INACTIVE    ACTIVATING    DEACTIVATING    RELOADING
consul-server         3         0           0             0               0            0
fleet-statsd          0         0           0             1               0            0
```

@pwillemse can we review this together?